### PR TITLE
Fix comment typo in video downloader

### DIFF
--- a/src/berean_transcripts/get_sermon_sections.py
+++ b/src/berean_transcripts/get_sermon_sections.py
@@ -92,10 +92,12 @@ def download_video(url, outfile_name, download_dir=videos_dir):
             # "format": "bestvideo+bestaudio/best",
             "format": "mp4",
             "outtmpl": str(download_dir / outfile_name),
-            # 'postprocessors': [{
-            #     'key': 'FFmpegVideoConvertor',
-            #     'preferedformat': 'mp4',
-            # }]
+            # 'postprocessors': [
+            #     {
+            #         'key': 'FFmpegVideoConvertor',
+            #         'preferredformat': 'mp4',
+            #     }
+            # ]
         }
         with YoutubeDL(options) as ydl:
             print(f"Downloading: {url}")


### PR DESCRIPTION
## Summary
- correct comment syntax under `download_video` options
- fix spelling of `'preferredformat'`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ce1e55fc8331be500b32a03bc4ca